### PR TITLE
Prevent form submission

### DIFF
--- a/dist/ol3-search-layer.js
+++ b/dist/ol3-search-layer.js
@@ -39,7 +39,7 @@ function SearchLayer(optOptions) {
 
   var form = document.createElement('form');
   form.setAttribute('id', 'random');
-  form.onsubmit = undefined;
+  form.onsubmit = function(){return false};
   // form.setAttribute('action', 'javascript:void(0);');
 
   var input = document.createElement('input');


### PR DESCRIPTION
Prevent the search form from being submitted, which would cause an
unwanted HTTP request and possibly result in the user's browser
being redirected. Submission can happen if the user presses the
"enter" key while in the search box. Form submission is prevented
by defining an "onsubmit" handler which always returning false.