### PR TITLE
Fix capitalization of Point

### DIFF
--- a/dist/ol3-search-layer.js
+++ b/dist/ol3-search-layer.js
@@ -84,7 +84,7 @@ function SearchLayer(optOptions) {
   ];
 
   var typesToZoomToCenterAndZoom = [
-    'point'
+    'Point'
   ];
   var returnHorsey = function(input, source, map, select, options) {
     horsey(input, {


### PR DESCRIPTION
Fix capitalization of "Point" geometry type. This fixes a bug
which prevented OL3 from zooming and centering to search results
which are Point geometries.

Tested with OpenLayers v3.20.1.